### PR TITLE
Add Tailwind bundling step to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,46 @@
-FROM golang:1.21.2 as builder
+#### Tailwind CSS build stage
+FROM node:20 as tailwindbuilder
 
+# Set a temporary work directory
+WORKDIR /app/tailwind
+
+# Copy in the project files
+COPY . .
+
+# Install Tailwind CLI
+RUN npm install tailwindcss
+
+# Generate minified Tailwind CSS bundle
+RUN npx tailwind -i tailwind.css -o tailwind-bundle.min.css --minify
+
+#### Go build stage
+FROM golang:1.21.2 as gobuilder
+
+# Set a temporary work directory
 WORKDIR /app
 
+# Add necessary go files
 COPY go.mod go.sum ./
 
 RUN go mod download
 
 COPY . .
 
+# Copy minified Tailwind CSS bundle
+COPY --from=tailwindbuilder /app/tailwind/tailwind-bundle.min.css ./static/tailwind-bundle.min.css
+
+# Build the go binary
 RUN CGO_ENABLED=0 GOOS=linux go build -o main .
 
-####
-
-FROM alpine:latest  
+#### Build final image
+FROM alpine:latest
 
 RUN apk --no-cache add ca-certificates
 
 WORKDIR /root/
 
-COPY --from=builder /app/main .
+# Copy Go binary
+COPY --from=gobuilder /app/main .
 
-CMD ["./main"] 
-
+# Run the application
+CMD ["./main"]


### PR DESCRIPTION
Refactors the Dockerfile into multiple stages. First stage is to build the minified Tailwind CSS bundle. Next it builds the final Go binary. In the last step, it builds the Docker image that will run the application. Alpine has a minimal amount of dependencies which gives us a smaller attack surface.