### PR TITLE
added to footer a njump.me home link and a seperate github link

### DIFF
--- a/templates/footer.html
+++ b/templates/footer.html
@@ -4,9 +4,12 @@
 
 <footer class="mb-4 mt-6 text-gray-400 text-sm text-center">
   powered by
-  <a class="underline text-gray-400" href="https://github.com/fiatjaf/njump"
+  <a class="underline text-gray-400" href="https://njump.me"
     >njump</a
-  >
+  > & open-sourced on
+  <a class="underline text-gray-400" href="https://github.com/fiatjaf/njump"
+    >github</a
+  > 
 </footer>
 
 <svg width="0" height="0" version="1.1" xmlns="http://www.w3.org/2000/svg">


### PR DESCRIPTION
The njump.me website was missing a "home" link to root. This commit adds it to the footer in the "powered by [njump]()" message, that previously redirected to the github page.

The github link is now added in an "open-sourced on [github]()" message. The new footer is on the format:

"powered by njump & open-sourced on github"

Now linking to both home and the github page.