### PR TITLE
adding relay.nos.social as a profile look up relay

### DIFF
--- a/nostr.go
+++ b/nostr.go
@@ -36,6 +36,7 @@ var (
 	profiles = []string{
 		"wss://purplepag.es",
 		"wss://relay.noswhere.com",
+		"wss://relay.nos.social",
 	}
 	justIds = []string{
 		"wss://cache2.primal.net/v1",


### PR DESCRIPTION
relay.nos.social is a profile caching relay similar to purplepag.es, driven by: https://github.com/planetary-social/nos-event-service

It's got some content which isn't on purplepages which would be useful for njump instances. 