### PR TITLE
Fix rendering of inline custom emoji whose aspect ratio isn't 1:1

### DIFF
--- a/common.templ
+++ b/common.templ
@@ -25,7 +25,7 @@ templ headCommonTemplate(params HeadParams) {
 	}
 	<style>
 	.note { line-height: 0px; }
-	.note img.emoji { width: 1em; height: 1em; display: inline; margin: 0px; }
+	.note img.emoji { height: 1em; display: inline; margin: 0px; }
 	@media print { @page { margin: 2cm 3cm; } }
 	</style>
 	<meta name="theme-color" content="#e42a6d"/>


### PR DESCRIPTION
With the current implementation, inline custom emojis are forced to be rendered in the aspect ratio 1:1 even if the intrinsic aspect ratio isn't 1:1.

As a result, for example, the body of the 'neck paca' gets squashed.

![Screenshot from 2024-02-14 01-10-55](https://github.com/fiatjaf/njump/assets/12131273/1a60d4e3-9a6e-4cfd-96a3-614c3c36f6a9)

This PR fixes this, by preserving intrinsic aspect ratio of emoji image.

AFAIK most of custom emojis whose aspect ratio isn't 1:1 are horizontally long, so matching the image height to the line height is a reasonable choice.

![Screenshot from 2024-02-14 01-11-46](https://github.com/fiatjaf/njump/assets/12131273/4c0e4379-5572-4f83-aa03-7f05c81de9ab)
