### PR TITLE
fixing dockerfile build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN npm install tailwindcss
 RUN npx tailwind -i base.css -o tailwind-bundle.min.css --minify
 
 #### Go build stage
-FROM golang:1.23.0-alpine AS gobuilder
+FROM golang:1.23.3-alpine AS gobuilder
 
 # Add package
 RUN apk add --no-cache autoconf automake libtool build-base musl-dev git


### PR DESCRIPTION
bumping go image to latest version to fix the build
```
 => ERROR [gobuilder 5/9] RUN go mod download                                                                                                                                       0.2s 
------                                                                                                                                                                                   
 > [gobuilder 5/9] RUN go mod download:                                                                                                                                                  
0.123 go: go.mod requires go >= 1.23.1 (running go 1.23.0; GOTOOLCHAIN=local)
------
Dockerfile:27
--------------------
  25 |     WORKDIR /app
  26 |     COPY --link . .
  27 | >>> RUN go mod download
  28 |     
  29 |     # Copy minified Tailwind CSS bundle

```