### PR TITLE
Respect Bluesky's !no-unauthenticated label and 404

### DIFF
--- a/metadata.go
+++ b/metadata.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"github.com/nbd-wtf/go-nostr/sdk"
+)
+
+// check if the user has requested to not be indexed
+// https://gitlab.com/soapbox-pub/ditto/-/merge_requests/596
+func indexOptOut(p sdk.ProfileMetadata) bool {
+	if p.Event == nil {
+		return false
+	}
+
+	for _, tag := range p.Event.Tags {
+		if tag[0] == "l" && tag[1] == "!no-unauthenticated" && tag[2] == "com.atproto.label.defs#selfLabel" {
+			return true
+		}
+	}
+
+	return false
+}

--- a/render_event.go
+++ b/render_event.go
@@ -106,6 +106,14 @@ func renderEvent(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// user has requested to not be indexed, 404
+	if indexOptOut(data.event.author) {
+		w.Header().Set("Cache-Control", "max-age=60")
+		w.WriteHeader(http.StatusNotFound)
+		errorTemplate(ErrorPageParams{Errors: "user has requested to not be indexed"}).Render(ctx, w)
+		return
+	}
+
 	// gather page style from user-agent
 	style := getPreviewStyle(r)
 

--- a/render_profile.go
+++ b/render_profile.go
@@ -43,6 +43,13 @@ func renderProfile(ctx context.Context, r *http.Request, w http.ResponseWriter, 
 		return
 	}
 
+	if indexOptOut(profile) {
+		w.Header().Set("Cache-Control", "max-age=60")
+		w.WriteHeader(http.StatusNotFound)
+		errorTemplate(ErrorPageParams{Errors: "user has requested to not be indexed"}).Render(ctx, w)
+		return
+	}
+
 	var createdAt string
 	if profile.Event != nil {
 		createdAt = profile.Event.CreatedAt.Time().Format("2006-01-02T15:04:05Z07:00")


### PR DESCRIPTION
This allows users to opt-out of being indexed by njump by adding a tag to their kind 0 that looks like this:

```json
["l", "!no-unauthenticated", "com.atproto.label.defs#selfLabel"]
```

The Bluesky bridge adds this tags for Bluesky users who enabled this setting in Bluesky:

![image](https://github.com/user-attachments/assets/147f87dd-d7b8-4f6b-bb43-a4ab4ff75af1)

I think it would be good to do this for diplomacy with Bluesky. And I think it would be fine if it became a feature of Nostr. It's similar to `robots.txt`

I also implemented in Ditto here: https://gitlab.com/soapbox-pub/ditto/-/merge_requests/596