### PR TITLE
Fix query param lost on redirect

### DIFF
--- a/render_event.go
+++ b/render_event.go
@@ -75,7 +75,11 @@ func renderEvent(w http.ResponseWriter, r *http.Request) {
 	// if we originally got a note code or an nevent with no hints
 	// augment the URL to point to an nevent with hints -- redirect
 	if p, ok := decoded.(nostr.EventPointer); (ok && p.Author == "" && len(p.Relays) == 0) || prefix == "note" {
-		http.Redirect(w, r, "/"+data.nevent, http.StatusFound)
+		url := "/" + data.nevent
+		if r.URL.RawQuery != "" {
+			url += "?" + r.URL.RawQuery
+		}
+		http.Redirect(w, r, url, http.StatusFound)
 		return
 	}
 


### PR DESCRIPTION
Fix #106 

Tested with the URL from the issue:

https://github.com/user-attachments/assets/d882b683-18a9-4416-bcbc-3568467988ac

Btw, really nice developer experience, I could get it to run with just `nix-shell -p just entr fd && just`!