### PR TITLE
build(docker): fix build issues by switching to golang:1-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN npm install tailwindcss
 RUN npx tailwind -i base.css -o tailwind-bundle.min.css --minify
 
 #### Go build stage
-FROM golang:1.24.2-alpine AS gobuilder
+FROM golang:1-alpine AS gobuilder
 
 # Add package
 RUN apk add --no-cache autoconf automake libtool build-base musl-dev git


### PR DESCRIPTION
The Go version in `go.mod` is 1.25, so the build fails. This is just a small fix.

Build log after the change:

```
#0 building with "default" instance using docker driver

#1 [internal] load build definition from Dockerfile
#1 transferring dockerfile:
#1 transferring dockerfile: 1.48kB done
#1 DONE 0.3s

#2 [auth] docker/dockerfile:pull token for registry-1.docker.io
#2 DONE 0.0s

#3 resolve image config for docker-image://docker.io/docker/dockerfile:1.4
#3 DONE 3.8s

#4 docker-image://docker.io/docker/dockerfile:1.4@sha256:9ba7531bd80fb0a858632727cf7a112fbfd19b17e94c4e84ced81e24ef1a0dbc
#4 resolve docker.io/docker/dockerfile:1.4@sha256:9ba7531bd80fb0a858632727cf7a112fbfd19b17e94c4e84ced81e24ef1a0dbc
#4 resolve docker.io/docker/dockerfile:1.4@sha256:9ba7531bd80fb0a858632727cf7a112fbfd19b17e94c4e84ced81e24ef1a0dbc 0.2s done
#4 sha256:9ba7531bd80fb0a858632727cf7a112fbfd19b17e94c4e84ced81e24ef1a0dbc 2.00kB / 2.00kB done
#4 sha256:ad87fb03593d1b71f9a1cfc1406c4aafcb253b1dabebf569768d6e6166836f34 528B / 528B done
#4 sha256:1e8a16826fd1c80a63fa6817a9c7284c94e40cded14a9b0d0d3722356efa47bd 2.37kB / 2.37kB done
#4 sha256:1328b32c40fca9bcf9d70d8eccb72eb873d1124d72dadce04db8badbe7b08546 0B / 9.94MB 0.1s
#4 sha256:1328b32c40fca9bcf9d70d8eccb72eb873d1124d72dadce04db8badbe7b08546 2.10MB / 9.94MB 0.6s
#4 sha256:1328b32c40fca9bcf9d70d8eccb72eb873d1124d72dadce04db8badbe7b08546 9.94MB / 9.94MB 0.8s
#4 sha256:1328b32c40fca9bcf9d70d8eccb72eb873d1124d72dadce04db8badbe7b08546 9.94MB / 9.94MB 0.9s done
#4 extracting sha256:1328b32c40fca9bcf9d70d8eccb72eb873d1124d72dadce04db8badbe7b08546
#4 extracting sha256:1328b32c40fca9bcf9d70d8eccb72eb873d1124d72dadce04db8badbe7b08546 0.1s done
#4 DONE 1.8s

#5 [internal] load .dockerignore
#5 transferring context:
#5 transferring context: 59B done
#5 DONE 0.3s

#6 [internal] load metadata for docker.io/library/alpine:latest
#6 ...

#7 [auth] library/node:pull token for registry-1.docker.io
#7 DONE 0.0s

#8 [auth] library/golang:pull token for registry-1.docker.io
#8 DONE 0.0s

#9 [auth] library/alpine:pull token for registry-1.docker.io
#9 DONE 0.0s

#10 [internal] load metadata for docker.io/library/golang:1-alpine
#10 DONE 3.1s

#11 [internal] load metadata for docker.io/library/node:23-slim
#11 DONE 3.3s

#6 [internal] load metadata for docker.io/library/alpine:latest
#6 DONE 3.4s

#12 [internal] load build context
#12 DONE 0.0s

#13 [gobuilder 1/8] FROM docker.io/library/golang:1-alpine@sha256:d3f0cf7723f3429e3f9ed846243970b20a2de7bae6a5b66fc5914e228d831bbb
#13 resolve docker.io/library/golang:1-alpine@sha256:d3f0cf7723f3429e3f9ed846243970b20a2de7bae6a5b66fc5914e228d831bbb
#13 resolve docker.io/library/golang:1-alpine@sha256:d3f0cf7723f3429e3f9ed846243970b20a2de7bae6a5b66fc5914e228d831bbb 0.5s done
#13 sha256:d3f0cf7723f3429e3f9ed846243970b20a2de7bae6a5b66fc5914e228d831bbb 10.29kB / 10.29kB done
#13 sha256:96f36e77302b6982abdd9849dff329feef03b0f2520c24dc2352fc4b33ed776d 1.92kB / 1.92kB done
#13 sha256:f86e735e7a39c546c1f105f637c63efcf44f4d6d285f9d8f524c1c62d9125377 2.17kB / 2.17kB done
#13 ...

#12 [internal] load build context
#12 transferring context: 66.48MB 2.2s done
#12 DONE 3.4s

#14 [tailwindbuilder 1/5] FROM docker.io/library/node:23-slim@sha256:86191b94d2a163be41f3dc7fe5e5fcaca8ba2f1be7275d98a06343483c17414a
#14 resolve docker.io/library/node:23-slim@sha256:86191b94d2a163be41f3dc7fe5e5fcaca8ba2f1be7275d98a06343483c17414a 0.5s done
#14 sha256:86191b94d2a163be41f3dc7fe5e5fcaca8ba2f1be7275d98a06343483c17414a 6.49kB / 6.49kB done
#14 sha256:a78efbd97936b0c0b5f65365ccc403c4c9b7217514e20cf1e589e9cac541c949 1.93kB / 1.93kB done
#14 sha256:16ec66a72742ca4edf87bca19952586f7d2906f523406cc90e9a5510a306bd59 6.58kB / 6.58kB done
#14 sha256:61320b01ae5e0798393ef25f2dc72faf43703e60ba089b07d7170acbabbf8f62 28.23MB / 28.23MB 2.9s done
#14 sha256:58d4fec821406039576f9007865c87db5b2a328223c70c1dccf9cbb5dd680e8b 25.17MB / 49.99MB 3.0s
#14 sha256:25b64eb3daf576c6c265d8966ff4a47c3595f1442060f8a2b44b25d5f85f2828 3.31kB / 3.31kB 2.5s done
#14 sha256:7f2930328747fd6a689b7b97d6ecdbe8f5064e2098950022f4f892f0731ff717 0B / 1.71MB 3.0s
#14 extracting sha256:61320b01ae5e0798393ef25f2dc72faf43703e60ba089b07d7170acbabbf8f62
#14 ...

#15 [stage-2 1/5] FROM docker.io/library/alpine:latest@sha256:4b7ce07002c69e8f3d704a9c5d6fd3053be500b7f1c69fc0d80990c2ad8dd412
#15 resolve docker.io/library/alpine:latest@sha256:4b7ce07002c69e8f3d704a9c5d6fd3053be500b7f1c69fc0d80990c2ad8dd412 0.5s done
#15 sha256:4b7ce07002c69e8f3d704a9c5d6fd3053be500b7f1c69fc0d80990c2ad8dd412 9.22kB / 9.22kB done
#15 sha256:85f2b723e106c34644cd5851d7e81ee87da98ac54672b29947c052a45d31dc2f 1.02kB / 1.02kB done
#15 sha256:706db57fb2063f39f69632c5b5c9c439633fda35110e65587c5d85553fd1cc38 581B / 581B done
#15 DONE 4.2s

#14 [tailwindbuilder 1/5] FROM docker.io/library/node:23-slim@sha256:86191b94d2a163be41f3dc7fe5e5fcaca8ba2f1be7275d98a06343483c17414a
#14 sha256:58d4fec821406039576f9007865c87db5b2a328223c70c1dccf9cbb5dd680e8b 30.41MB / 49.99MB 3.2s
#14 sha256:dd777430329500339de653c3cb2a5821e1fab691c823e955fb84220ccca58ae0 0B / 448B 3.2s
#14 sha256:58d4fec821406039576f9007865c87db5b2a328223c70c1dccf9cbb5dd680e8b 35.65MB / 49.99MB 3.4s
#14 sha256:58d4fec821406039576f9007865c87db5b2a328223c70c1dccf9cbb5dd680e8b 39.85MB / 49.99MB 3.6s
#14 sha256:58d4fec821406039576f9007865c87db5b2a328223c70c1dccf9cbb5dd680e8b 42.99MB / 49.99MB 3.7s
#14 sha256:7f2930328747fd6a689b7b97d6ecdbe8f5064e2098950022f4f892f0731ff717 1.71MB / 1.71MB 3.8s
#14 extracting sha256:61320b01ae5e0798393ef25f2dc72faf43703e60ba089b07d7170acbabbf8f62 0.8s done
#14 sha256:58d4fec821406039576f9007865c87db5b2a328223c70c1dccf9cbb5dd680e8b 49.99MB / 49.99MB 4.0s
#14 sha256:dd777430329500339de653c3cb2a5821e1fab691c823e955fb84220ccca58ae0 448B / 448B 4.0s
#14 sha256:7f2930328747fd6a689b7b97d6ecdbe8f5064e2098950022f4f892f0731ff717 1.71MB / 1.71MB 3.9s done
#14 sha256:dd777430329500339de653c3cb2a5821e1fab691c823e955fb84220ccca58ae0 448B / 448B 5.3s done
#14 sha256:58d4fec821406039576f9007865c87db5b2a328223c70c1dccf9cbb5dd680e8b 49.99MB / 49.99MB 5.8s done
#14 extracting sha256:25b64eb3daf576c6c265d8966ff4a47c3595f1442060f8a2b44b25d5f85f2828 done
#14 ...

#13 [gobuilder 1/8] FROM docker.io/library/golang:1-alpine@sha256:d3f0cf7723f3429e3f9ed846243970b20a2de7bae6a5b66fc5914e228d831bbb
#13 sha256:8005175e490b0ff92097d506946bbecbb38ca5479503236dcb3350f2da29b1cb 291.16kB / 291.16kB 6.8s done
#13 sha256:7c9d4a4eea0de466b378fec1876ea74acd9465fc6a1d15368a117eeacaa21b7d 60.15MB / 60.15MB 10.2s
#13 sha256:ae96bccb6682de86f077a4ef76a3024218e06114ae177db9ad565f2be5a0e423 126B / 126B 10.2s
#13 extracting sha256:8005175e490b0ff92097d506946bbecbb38ca5479503236dcb3350f2da29b1cb 2.9s done
#13 sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1 0B / 32B 10.2s
#13 sha256:ae96bccb6682de86f077a4ef76a3024218e06114ae177db9ad565f2be5a0e423 126B / 126B 10.3s done
#13 sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1 32B / 32B 10.5s
#13 sha256:7c9d4a4eea0de466b378fec1876ea74acd9465fc6a1d15368a117eeacaa21b7d 60.15MB / 60.15MB 10.5s done
#13 sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1 32B / 32B 10.6s done
#13 extracting sha256:7c9d4a4eea0de466b378fec1876ea74acd9465fc6a1d15368a117eeacaa21b7d
#13 ...

#16 [stage-2 2/5] RUN apk --no-cache add ca-certificates
#16 2.803 fetch https://dl-cdn.alpinelinux.org/alpine/v3.22/main/x86_64/APKINDEX.tar.gz
#16 3.553 fetch https://dl-cdn.alpinelinux.org/alpine/v3.22/community/x86_64/APKINDEX.tar.gz
#16 4.005 (1/1) Installing ca-certificates (20250911-r0)
#16 7.776 Executing busybox-1.37.0-r19.trigger
#16 7.816 Executing ca-certificates-20250911-r0.trigger
#16 7.932 OK: 8 MiB in 17 packages
#16 ...

#13 [gobuilder 1/8] FROM docker.io/library/golang:1-alpine@sha256:d3f0cf7723f3429e3f9ed846243970b20a2de7bae6a5b66fc5914e228d831bbb
#13 extracting sha256:7c9d4a4eea0de466b378fec1876ea74acd9465fc6a1d15368a117eeacaa21b7d 3.3s done
#13 ...

#16 [stage-2 2/5] RUN apk --no-cache add ca-certificates
#16 DONE 12.1s

#14 [tailwindbuilder 1/5] FROM docker.io/library/node:23-slim@sha256:86191b94d2a163be41f3dc7fe5e5fcaca8ba2f1be7275d98a06343483c17414a
#14 extracting sha256:58d4fec821406039576f9007865c87db5b2a328223c70c1dccf9cbb5dd680e8b 1.3s done
#14 extracting sha256:7f2930328747fd6a689b7b97d6ecdbe8f5064e2098950022f4f892f0731ff717
#14 ...

#13 [gobuilder 1/8] FROM docker.io/library/golang:1-alpine@sha256:d3f0cf7723f3429e3f9ed846243970b20a2de7bae6a5b66fc5914e228d831bbb
#13 extracting sha256:ae96bccb6682de86f077a4ef76a3024218e06114ae177db9ad565f2be5a0e423
#13 extracting sha256:ae96bccb6682de86f077a4ef76a3024218e06114ae177db9ad565f2be5a0e423 done
#13 ...

#17 [stage-2 3/5] WORKDIR /root
#17 DONE 4.3s

#14 [tailwindbuilder 1/5] FROM docker.io/library/node:23-slim@sha256:86191b94d2a163be41f3dc7fe5e5fcaca8ba2f1be7275d98a06343483c17414a
#14 extracting sha256:7f2930328747fd6a689b7b97d6ecdbe8f5064e2098950022f4f892f0731ff717 0.7s done
#14 extracting sha256:dd777430329500339de653c3cb2a5821e1fab691c823e955fb84220ccca58ae0
#14 extracting sha256:dd777430329500339de653c3cb2a5821e1fab691c823e955fb84220ccca58ae0 done
#14 ...

#13 [gobuilder 1/8] FROM docker.io/library/golang:1-alpine@sha256:d3f0cf7723f3429e3f9ed846243970b20a2de7bae6a5b66fc5914e228d831bbb
#13 extracting sha256:4f4fb700ef54461cfa02571ae0db9a0dc1e0cdb5577484a6d75e68dc38e8acc1 done
#13 DONE 25.2s

#18 [gobuilder 2/8] RUN apk add --no-cache autoconf automake libtool build-base musl-dev git
#18 ...

#14 [tailwindbuilder 1/5] FROM docker.io/library/node:23-slim@sha256:86191b94d2a163be41f3dc7fe5e5fcaca8ba2f1be7275d98a06343483c17414a
#14 DONE 25.9s

#19 [tailwindbuilder 2/5] WORKDIR /app/tailwind
#19 DONE 0.6s

#18 [gobuilder 2/8] RUN apk add --no-cache autoconf automake libtool build-base musl-dev git
#18 1.306 fetch https://dl-cdn.alpinelinux.org/alpine/v3.22/main/x86_64/APKINDEX.tar.gz
#18 2.001 fetch https://dl-cdn.alpinelinux.org/alpine/v3.22/community/x86_64/APKINDEX.tar.gz
#18 2.411 (1/42) Installing m4 (1.4.19-r4)
#18 3.020 (2/42) Installing libbz2 (1.0.8-r6)
#18 ...

#20 [tailwindbuilder 3/5] COPY --link . .
#20 DONE 2.0s

#18 [gobuilder 2/8] RUN apk add --no-cache autoconf automake libtool build-base musl-dev git
#18 3.389 (3/42) Installing perl (5.40.3-r0)
#18 4.455 (4/42) Installing autoconf (2.72-r1)
#18 4.553 (5/42) Installing automake (1.17-r1)
#18 4.655 (6/42) Installing libgcc (14.2.0-r6)
#18 4.738 (7/42) Installing jansson (2.14.1-r0)
#18 4.821 (8/42) Installing libstdc++ (14.2.0-r6)
#18 4.917 (9/42) Installing zstd-libs (1.5.7-r0)
#18 5.005 (10/42) Installing binutils (2.44-r3)
#18 5.148 (11/42) Installing libmagic (5.46-r2)
#18 5.278 (12/42) Installing file (5.46-r2)
#18 5.361 (13/42) Installing libgomp (14.2.0-r6)
#18 5.447 (14/42) Installing libatomic (14.2.0-r6)
#18 5.530 (15/42) Installing gmp (6.3.0-r3)
#18 5.616 (16/42) Installing isl26 (0.26-r1)
#18 5.711 (17/42) Installing mpfr4 (4.2.1_p1-r0)
#18 5.799 (18/42) Installing mpc1 (1.3.1-r1)
#18 5.882 (19/42) Installing gcc (14.2.0-r6)
#18 7.548 (20/42) Installing libstdc++-dev (14.2.0-r6)
#18 7.770 (21/42) Installing musl-dev (1.2.5-r10)
#18 7.931 (22/42) Installing g++ (14.2.0-r6)
#18 8.405 (23/42) Installing make (4.4.1-r3)
#18 8.494 (24/42) Installing fortify-headers (1.1-r5)
#18 8.577 (25/42) Installing patch (2.8-r0)
#18 8.661 (26/42) Installing build-base (0.5-r3)
#18 8.661 (27/42) Installing brotli-libs (1.1.0-r2)
#18 8.752 (28/42) Installing c-ares (1.34.5-r0)
#18 8.837 (29/42) Installing libunistring (1.3-r0)
#18 8.934 (30/42) Installing libidn2 (2.3.7-r0)
#18 9.019 (31/42) Installing nghttp2-libs (1.65.0-r0)
#18 9.104 (32/42) Installing libpsl (0.21.5-r3)
#18 9.187 (33/42) Installing libcurl (8.14.1-r2)
#18 9.277 (34/42) Installing libexpat (2.7.3-r0)
#18 9.360 (35/42) Installing pcre2 (10.46-r0)
#18 9.449 (36/42) Installing git (2.49.1-r0)
#18 9.607 (37/42) Installing git-init-template (2.49.1-r0)
#18 9.689 (38/42) Installing perl-error (0.17030-r0)
#18 9.771 (39/42) Installing perl-git (2.49.1-r0)
#18 9.855 (40/42) Installing git-perl (2.49.1-r0)
#18 9.937 (41/42) Installing libltdl (2.5.4-r1)
#18 10.02 (42/42) Installing libtool (2.5.4-r1)
#18 10.12 Executing busybox-1.37.0-r19.trigger
#18 10.33 OK: 298 MiB in 59 packages
#18 DONE 11.6s

#21 [tailwindbuilder 4/5] RUN npm install tailwindcss
#21 ...

#22 [gobuilder 3/8] WORKDIR /app
#22 DONE 0.6s

#21 [tailwindbuilder 4/5] RUN npm install tailwindcss
#21 ...

#23 [gobuilder 4/8] COPY --link . .
#23 DONE 2.8s

#21 [tailwindbuilder 4/5] RUN npm install tailwindcss
#21 ...

#24 [gobuilder 5/8] RUN go mod download
#24 DONE 10.8s

#21 [tailwindbuilder 4/5] RUN npm install tailwindcss
#21 23.60 
#21 23.60 added 77 packages, and audited 78 packages in 22s
#21 23.60 
#21 23.60 19 packages are looking for funding
#21 23.60   run `npm fund` for details
#21 23.60 
#21 23.60 found 0 vulnerabilities
#21 23.60 npm notice
#21 23.60 npm notice New major version of npm available! 10.9.2 -> 11.6.4
#21 23.60 npm notice Changelog: https://github.com/npm/cli/releases/tag/v11.6.4
#21 23.60 npm notice To update run: npm install -g npm@11.6.4
#21 23.60 npm notice
#21 DONE 25.6s

#25 [tailwindbuilder 5/5] RUN npx tailwind -i base.css -o tailwind-bundle.min.css --minify
#25 1.469 Browserslist: caniuse-lite is outdated. Please run:
#25 1.469   npx update-browserslist-db@latest
#25 1.469   Why you should do it regularly: https://github.com/browserslist/update-db#readme
#25 1.561 
#25 1.561 Rebuilding...
#25 2.213 
#25 2.213 Done in 684ms.
#25 DONE 2.6s

#26 [gobuilder 6/8] COPY --from=tailwindbuilder /app/tailwind/tailwind-bundle.min.css ./static/tailwind-bundle.min.css
#26 DONE 1.3s

#27 [gobuilder 7/8] RUN go get github.com/a-h/templ/runtime &&     go run -mod=mod github.com/a-h/templ/cmd/templ generate
#27 1.479 go: downloading github.com/fatih/color v1.16.0
#27 1.479 go: downloading github.com/natefinch/atomic v1.0.1
#27 1.479 go: downloading github.com/a-h/parse v0.0.0-20250122154542-74294addb73e
#27 1.480 go: downloading github.com/fsnotify/fsnotify v1.7.0
#27 1.769 go: downloading github.com/cli/browser v1.3.0
#27 1.769 go: downloading github.com/cenkalti/backoff/v4 v4.3.0
#27 13.48 (✓) Complete [ updates=0 duration=38.362585ms ]
#27 DONE 14.3s

#28 [gobuilder 8/8] RUN CGO_ENABLED=1 GOOS=linux GOARCH=amd64 CC=$(which musl-gcc)     go build -tags='libsecp256k1'     -ldflags="-s -w -linkmode external -extldflags '-static' -X main.compileTimeTs=$(date '+%s')"     -o main .
#28 DONE 50.0s

#29 [stage-2 4/5] COPY --from=gobuilder /app/main .
#29 DONE 1.4s

#30 [stage-2 5/5] COPY --from=gobuilder /app/relay-config.json.sample relay-config.json
#30 DONE 2.9s
```