### PR TITLE
fix: tailwind in npm install fails on missing tailwind.css

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "postinstall": "tailwind -i tailwind.css -o static/tailwind-bundle.min.css --minify"
+    "postinstall": "tailwind -i base.css -o static/tailwind-bundle.min.css --minify"
   },
   "dependencies": {
     "@tailwindcss/typography": "^0.5.10",


### PR DESCRIPTION
This fixes #143 by changing `tailwind.css` to `base.css` in `package.json` so that `npm install` works again.
Without you'd get:
```npm i

> postinstall
> tailwind -i tailwind.css -o static/tailwind-bundle.min.css --minify

Specified input file tailwind.css does not exist.
npm error code 9
npm error path [REDACTED]
npm error command failed
npm error command sh -c tailwind -i tailwind.css -o static/tailwind-bundle.min.css --minify
npm error A complete log of this run can be found in: [REDACTED]
```

Now it produces:
```
npm i

> postinstall
> tailwind -i base.css -o static/tailwind-bundle.min.css --minify

Browserslist: caniuse-lite is outdated. Please run:
npx update-browserslist-db@latest
Why you should do it regularly: https://github.com/browserslist/update-db#readme

Rebuilding...

Done in 799ms.

up to date, audited 78 packages in 2s

19 packages are looking for funding
run `npm fund` for details

found 0 vulnerabilities
```