### PR TITLE
fix: relay config now overrides all profile and justIds relay streams

### DIFF
--- a/main.go
+++ b/main.go
@@ -88,6 +88,11 @@ func main() {
 		}
 		if len(relayConfig.Profiles) > 0 {
 			sys.MetadataRelays.URLs = relayConfig.Profiles
+			sys.RelayListRelays.URLs = relayConfig.Profiles
+			sys.FollowListRelays.URLs = relayConfig.Profiles
+		}
+		if len(relayConfig.JustIds) > 0 {
+			sys.JustIDRelays.URLs = relayConfig.JustIds
 		}
 	}
 


### PR DESCRIPTION
##### Summary
- `profiles` config now overrides `MetadataRelays`, `RelayListRelays`, and `FollowListRelays`
- `justIds` config now overrides `JustIDRelays`
- Fixes #150 

##### Problem
The relay config file was only partially applied. Hardcoded defaults in `nostr.go` (including `purplepag.es`) were not being replaced for `RelayListRelays`, `FollowListRelays`, or `JustIDRelays`, even when those relays were removed from the config.

##### Fix
Extended the config loading logic in `main.go` to apply all relevant relay stream overrides when the config arrays are non-empty.
