### PR TITLE
Add Noornote web client

### DIFF
--- a/clients.json
+++ b/clients.json
@@ -209,6 +209,11 @@
       "name": "Wikifreedia",
       "base": "https://wikifreedia.xyz/{handle}/{npub}",
       "platform": "web"
+    },
+    "noornote": {
+      "name": "Noornote",
+      "base": "https://noornote.app/{code}",
+      "platform": "web"
     }
   },
   "kindMappings": {
@@ -249,7 +254,8 @@
       "phoenix",
       "primal-web",
       "iris",
-      "yakihonne"
+      "yakihonne",
+      "noornote"
     ],
     "6": [
       "native",
@@ -273,7 +279,8 @@
       "phoenix",
       "primal-web",
       "iris",
-      "yakihonne"
+      "yakihonne",
+      "noornote"
     ],
     "20": [
       "native",
@@ -309,6 +316,7 @@
       "primal-web",
       "iris",
       "yakihonne",
+      "noornote",
       "default-web"
     ],
     "9802": ["coracle", "nostrudel", "lumilumi", "jumble", "default-web"],
@@ -335,6 +343,7 @@
       "coracle",
       "pareto",
       "habla",
+      "noornote",
       "default-web"
     ],
     "30024": [
@@ -350,6 +359,7 @@
       "coracle",
       "pareto",
       "habla",
+      "noornote",
       "default-web"
     ],
     "30311": [


### PR DESCRIPTION
Add [Noornote](https://noornote.app) as a web client.

- Base URL: `https://noornote.app/{code}`
- Supports kinds: 0 (profiles), 1 (notes), 6 (reposts), 30023 (articles), 30024 (article drafts)