### PR TITLE
Add Ditto (ditto.pub) as a client app target

### DIFF
--- a/clients.json
+++ b/clients.json
@@ -209,6 +209,16 @@
       "name": "Wikifreedia",
       "base": "https://wikifreedia.xyz/{handle}/{npub}",
       "platform": "web"
+    },
+    "ditto": {
+      "name": "Ditto",
+      "base": "https://ditto.pub/{code}",
+      "platform": "web"
+    },
+    "ditto-relay": {
+      "name": "Ditto",
+      "base": "https://ditto.pub/r/wss://{code}",
+      "platform": "web"
     }
   },
   "kindMappings": {
@@ -223,6 +233,7 @@
       "nosotros-relay",
       "lumilumi-relay",
       "coracle-relay",
+      "ditto-relay",
       "relay-tools",
       "nostter-relay",
       "default-web"
@@ -243,6 +254,7 @@
       "nosotros",
       "jumble",
       "coracle",
+      "ditto",
       "lumilumi",
       "nostter",
       "nostrudel",
@@ -267,6 +279,7 @@
       "nosotros",
       "jumble",
       "coracle",
+      "ditto",
       "lumilumi",
       "nostter",
       "nostrudel",
@@ -284,6 +297,7 @@
       "jumble",
       "olas-web",
       "coracle",
+      "ditto",
       "default-web"
     ],
     "0": [
@@ -303,6 +317,7 @@
       "jumble",
       "nosta",
       "coracle",
+      "ditto",
       "phoenix",
       "nostter",
       "nostrudel",
@@ -333,6 +348,7 @@
       "yakihonne",
       "lumilumi",
       "coracle",
+      "ditto",
       "pareto",
       "habla",
       "default-web"
@@ -348,6 +364,7 @@
       "yakihonne",
       "lumilumi",
       "coracle",
+      "ditto",
       "pareto",
       "habla",
       "default-web"
@@ -360,6 +377,7 @@
       "shosho",
       "lumilumi",
       "nostrudel",
+      "ditto",
       "default-web"
     ],
     "30818": ["native", "wikistr", "wikifreedia", "default-web"],
@@ -382,6 +400,7 @@
       "voyage",
       "yakihonne",
       "coracle",
+      "ditto",
       "phoenix",
       "nostter",
       "nostrudel",


### PR DESCRIPTION
## Summary

- Adds [Ditto](https://ditto.pub) as a web client app target in `clients.json`
- Adds `ditto` client definition with URL pattern `https://ditto.pub/{code}` (supports NIP-19 entities directly in the URL path)
- Adds `ditto-relay` client definition with URL pattern `https://ditto.pub/r/wss://{code}` for relay pages
- Adds Ditto to kind mappings for: notes (1), reposts (6), photos (20), profiles (0), articles (30023, 30024), live streams (30311), relays (-1), and the default fallback

Ditto is an open-source Nostr client by Soapbox that supports a wide range of content types including text notes, articles, photos, live streams, and more.