### PR TITLE
fix: always fetch latest version of replaceable events from relays

### DIFF
--- a/nostr.go
+++ b/nostr.go
@@ -177,8 +177,10 @@ func getEvent(ctx context.Context, code string) (*nostr.Event, error) {
 		break
 	}
 
-	// otherwise try the relays
-	if event == nil {
+	// for replaceable events (naddr) always try relays too since the local copy may be outdated
+	_, isReplaceable := pointer.(nostr.EntityPointer)
+
+	if event == nil || isReplaceable {
 		await(ctx)
 
 		evt, _, err := sys.FetchSpecificEvent(ctx, pointer, sdk.FetchSpecificEventParameters{
@@ -186,10 +188,17 @@ func getEvent(ctx context.Context, code string) (*nostr.Event, error) {
 			SaveToLocalStore: true,
 		})
 		if err != nil {
+			if event != nil {
+				// we had a local copy, use it as fallback
+				goto afterFetch
+			}
 			return evt, err
 		}
-		event = evt
+		if evt != nil && (event == nil || evt.CreatedAt > event.CreatedAt) {
+			event = evt
+		}
 	}
+afterFetch:
 
 	if event != nil {
 		// do banned checks again if necessary


### PR DESCRIPTION
## Problem

When viewing a replaceable event via `naddr` (e.g. a kind 30023 long-form article), njump serves a stale cached version and never checks relays for updates.

**Live example:** [this article on njump](https://njump.me/naddr1qq3kuctdv43k76tw945kuar9vaexzarfdahz6ctdv46xs7tnwskkwatfv3jszyrhwden5te0dehhxarj9emkjmn9qgsyxxz7mm9kwkyjsf935da90ulyqlaautk6wgq68q5m3n6t5lzmfuqrqsqqqa28ledaun) is missing the latest edit, while [the same event on yakihonne](https://yakihonne.com/article/naddr1qq3kuctdv43k76tw945kuar9vaexzarfdahz6ctdv46xs7tnwskkwatfv3jszyrhwden5te0dehhxarj9emkjmn9qgsyxxz7mm9kwkyjsf935da90ulyqlaautk6wgq68q5m3n6t5lzmfuqrqsqqqa28ledaun) shows the current version.

In `getEvent()`, the local store is checked first. If **any** version of the event exists locally, the function returns it immediately without ever querying relays:

```go
// first check localstore
var event *nostr.Event
for evt := range sys.Store.QueryEvents(pointer.AsFilter(), 1) {
    event = &evt
    break
}

// otherwise try the relays
if event == nil {  // <-- never true once cached
```

This means once a replaceable event is cached, edits are never picked up. The event stays frozen at whatever version was first fetched.

## Fix

For `EntityPointer` (`naddr`) lookups, always query relays even when a local copy exists. The event with the higher `created_at` wins. If the relay fetch fails but a local copy exists, the local copy is used as a fallback so there is no regression for offline/unreachable relay scenarios.

## How to reproduce

1. Publish a kind 30023 article via any Nostr client
2. View it on njump — content appears correctly
3. Edit the article (publish an update with the same `d` tag)
4. View it on njump again — still shows the old version
5. View it on yakihonne or another client — shows the updated version