### PR TITLE
fix nil error dereference in oembed url validation

### DIFF
--- a/oembed.go
+++ b/oembed.go
@@ -42,7 +42,7 @@ func renderOEmbed(w http.ResponseWriter, r *http.Request) {
 	targetURL, err := url.Parse(r.URL.Query().Get("url"))
 	if err != nil || !strings.Contains(targetURL.Path, "/") {
 		msg := "unexpected url path"
-		if err == nil {
+		if err != nil {
 			msg = err.Error()
 		}
 		http.Error(w, "invalid url: "+msg, 400)


### PR DESCRIPTION
The error branch in renderOEmbed called err.Error() when err was nil. The block is entered when url.Parse fails OR the path has no slash; in the latter case err is nil, so err.Error() dereferences a nil error and panics. Invert the condition to only use err.Error() when err is non-nil, keeping the default message otherwise.