### PR TITLE
fix inverted condition skipping placeholder tag replacement

### DIFF
--- a/render_event.go
+++ b/render_event.go
@@ -255,7 +255,7 @@ func renderEvent(w http.ResponseWriter, r *http.Request) {
 		default:
 			continue
 		}
-		if err == nil {
+		if err != nil {
 			continue
 		}
 		data.content = strings.ReplaceAll(data.content, placeholderTag, "nostr:"+nip19.EncodePointer(nreplace))


### PR DESCRIPTION
When refactoring the legacy #[index] mention replacement to use pointer parsing, the condition was inverted to if err == nil { continue }. This skips the replacement exactly when the tag was parsed successfully, and instead falls through to EncodePointer with a zero pointer when parsing failed. Flip it to if err != nil { continue } so that valid p/e/a tags are replaced and failed parses are skipped.