### PR TITLE
limit nip19 relay hints to three relays as intended

### DIFF
--- a/data.go
+++ b/data.go
@@ -125,13 +125,12 @@ func grabData(ctx context.Context, code string) (Data, error) {
 	ee.relays = sys.GetEventRelays(event.ID)
 
 	relaysForNip19 := make([]string, 0, 3)
-	c := 0
 	for _, relayUrl := range ee.relays {
 		if sdk.IsVirtualRelay(relayUrl) {
 			continue
 		}
 		relaysForNip19 = append(relaysForNip19, relayUrl)
-		if c == 2 {
+		if len(relaysForNip19) == 3 {
 			break
 		}
 	}


### PR DESCRIPTION
The counter c was never incremented, so the break never fired and all non-virtual relays were added to the nip19 hints instead of at most three. Cap the loop on the slice length and drop the dead counter.