### PR TITLE
guard against index out of range panics on malformed events

### DIFF
--- a/data.go
+++ b/data.go
@@ -368,7 +368,9 @@ func grabData(ctx context.Context, code string) (Data, error) {
 			data.image = data.kind1063Metadata.URL
 		} else if data.kind1063Metadata.IsVideo() {
 			data.video = data.kind1063Metadata.URL
-			data.videoType = strings.Split(data.kind1063Metadata.M, "/")[1]
+			if _, subtype, ok := strings.Cut(data.kind1063Metadata.M, "/"); ok {
+				data.videoType = subtype
+			}
 		}
 	} else if event.Kind == 20 || event.Kind == 21 || event.Kind == 22 {
 		imeta := nip92.ParseTags(event.Tags)

--- a/data.go
+++ b/data.go
@@ -164,13 +164,15 @@ func grabData(ctx context.Context, code string) (Data, error) {
 			if hTag := event.Tags.Find("h"); hTag != nil && len(hTag) > 1 {
 				groupId := hTag[1]
 				data.Kind39000Metadata.Address.ID = groupId
-				data.Kind39000Metadata.Address.Relay = ee.relays[0]
 
 				// try fetching kind 39000 group metadata from the relay where the event was found
 				if len(ee.relays) > 0 {
+					data.Kind39000Metadata.Address.Relay = ee.relays[0]
+
 					ctx, cancel := context.WithTimeout(ctx, time.Second*2)
 					defer cancel()
 
+				relayLoop:
 					for _, relay := range ee.relays {
 						info, err := nip11.Fetch(ctx, relay)
 						if err != nil || info.Self == nil {
@@ -190,7 +192,7 @@ func grabData(ctx context.Context, code string) (Data, error) {
 										data.Kind39000Metadata.MergeInMetadataEvent(&meta)
 										data.Kind39000Metadata.Address.Relay = relay.URL
 										data.Kind39000Metadata.Address.Self = *info.Self
-										break
+										break relayLoop
 									}
 								case <-ctx.Done():
 									// timeout, keep the fallback groupId

--- a/render_event.go
+++ b/render_event.go
@@ -492,7 +492,7 @@ func renderEvent(w http.ResponseWriter, r *http.Request) {
 		// Fallback for deprecated 'name' field
 		if data.kind31922Or31923Metadata.Title == "" {
 			for _, tag := range data.event.Tags {
-				if tag[0] == "name" {
+				if len(tag) >= 2 && tag[0] == "name" {
 					data.kind31922Or31923Metadata.Title = tag[1]
 					break
 				}

--- a/render_event.go
+++ b/render_event.go
@@ -132,7 +132,7 @@ func renderEvent(w http.ResponseWriter, r *http.Request) {
 	if data.event.Kind >= 30000 && data.event.Kind < 40000 {
 		tValue := "~"
 		for _, tag := range data.event.Tags {
-			if tag[0] == "t" {
+			if len(tag) >= 2 && tag[0] == "t" {
 				tValue = tag[1]
 				break
 			}


### PR DESCRIPTION
Several event handlers index into slices without checking their length, so a malformed or hostile event can crash the request. This fixes three such cases:

- kind:9 group messages dereference ee.relays[0] before the length check; move it inside the guard, and turn the inner break into a labelled break so the relay loop actually stops once metadata is found.
- kind:1063 file metadata splits the mime type on / and reads index 1, which panics when the type has no subtype (e.g. just "video"); use strings.Cut instead.
- subscript extraction and the calendar event name fallback iterate raw tags and read tag[0]/tag[1] without a length guard, panicking on empty or single-element tags.