### PR TITLE
guard against malformed highlight a tag coordinate panic

### DIFF
--- a/data.go
+++ b/data.go
@@ -287,14 +287,16 @@ func grabData(ctx context.Context, code string) (Data, error) {
 			data.Kind9802Metadata.SourceName = "#" + shortenString(sourceEvent[1], 8, 4)
 		} else if sourceEvent := event.Tags.Find("a"); sourceEvent != nil {
 			spl := strings.Split(sourceEvent[1], ":")
-			kind, _ := strconv.Atoi(spl[0])
-			var relayHints []string
-			if len(sourceEvent) > 2 {
-				relayHints = []string{sourceEvent[2]}
-			}
-			if pk, err := nostr.PubKeyFromHex(spl[1]); err == nil {
-				naddr := nip19.EncodeNaddr(pk, nostr.Kind(kind), spl[2], relayHints)
-				data.Kind9802Metadata.SourceEvent = naddr
+			if len(spl) >= 3 {
+				kind, _ := strconv.Atoi(spl[0])
+				var relayHints []string
+				if len(sourceEvent) > 2 {
+					relayHints = []string{sourceEvent[2]}
+				}
+				if pk, err := nostr.PubKeyFromHex(spl[1]); err == nil {
+					naddr := nip19.EncodeNaddr(pk, nostr.Kind(kind), spl[2], relayHints)
+					data.Kind9802Metadata.SourceEvent = naddr
+				}
 			}
 		} else if sourceUrl := event.Tags.Find("r"); sourceUrl != nil {
 			data.Kind9802Metadata.SourceURL = sourceUrl[1]


### PR DESCRIPTION
A kind:9802 highlight event referencing its source via an `a` tag splits the coordinate on `:` and accesses spl[1] and spl[2] without checking the length. A malformed coordinate with fewer than three parts caused an index out of range panic. The accesses are now guarded by a length check.