### PR TITLE
Add a translate button to note pages

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/srwiley/rasterx v0.0.0-20220730225603-2ab79fcdd4ef
 	github.com/stretchr/testify v1.10.0
 	github.com/texttheater/golang-levenshtein v1.0.1
+	github.com/translated/lara-go v1.5.1
 	github.com/tylermmorton/tmpl v0.0.0-20231025031313-5552ee818c6d
 	golang.org/x/image v0.18.0
 	golang.org/x/sync v0.19.0

--- a/go.sum
+++ b/go.sum
@@ -202,6 +202,8 @@ github.com/tidwall/match v1.2.0/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JT
 github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
 github.com/tidwall/pretty v1.2.1 h1:qjsOFOWWQl+N3RsoF5/ssm1pHmJJwhjlSbZ51I6wMl4=
 github.com/tidwall/pretty v1.2.1/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
+github.com/translated/lara-go v1.5.1 h1:6huToE5ITWlmhTRnBDbMtNYTnOpsvfCti4tlSx2q24k=
+github.com/translated/lara-go v1.5.1/go.mod h1:iWoVwvAmy8aPs1GXs4CbHv4rwTyNpJ1JjChdAX1cqag=
 github.com/tyler-smith/go-bip39 v1.1.0 h1:5eUemwrMargf3BSLRRCalXT93Ns6pQJIjYQN2nyfOP8=
 github.com/tyler-smith/go-bip39 v1.1.0/go.mod h1:gUYDtqQw1JS3ZJ8UWVcGTGqqr6YIN3CWg+kkNaLt55U=
 github.com/tylermmorton/tmpl v0.0.0-20231025031313-5552ee818c6d h1:DZ25KkbqQMYQE9Dk5x4WMJlBg39HSOn0HIn0t6cCSjI=

--- a/main.go
+++ b/main.go
@@ -32,9 +32,8 @@ type Settings struct {
 	MediaAlertAPIKey    string `envconfig:"MEDIA_ALERT_API_KEY"`
 	ErrorLogPath        string `envconfig:"ERROR_LOG_PATH" default:"/tmp/njump-errors.jsonl"`
 	CacheRetentionDays  int    `envconfig:"CACHE_RETENTION_DAYS" default:"13"`
-	TranslateAPIURL     string `envconfig:"TRANSLATE_API_URL"`
-	TranslateAPIKey     string `envconfig:"TRANSLATE_API_KEY"`
-	TranslateAPIEmail   string `envconfig:"TRANSLATE_API_EMAIL"`
+	LaraAccessKeyID     string `envconfig:"LARA_ACCESS_KEY_ID"`
+	LaraAccessKeySecret string `envconfig:"LARA_ACCESS_KEY_SECRET"`
 
 	TrustedPubKeysHex []string `envconfig:"TRUSTED_PUBKEYS"`
 	trustedPubKeys    []nostr.PubKey

--- a/main.go
+++ b/main.go
@@ -32,6 +32,9 @@ type Settings struct {
 	MediaAlertAPIKey    string `envconfig:"MEDIA_ALERT_API_KEY"`
 	ErrorLogPath        string `envconfig:"ERROR_LOG_PATH" default:"/tmp/njump-errors.jsonl"`
 	CacheRetentionDays  int    `envconfig:"CACHE_RETENTION_DAYS" default:"13"`
+	TranslateAPIURL     string `envconfig:"TRANSLATE_API_URL"`
+	TranslateAPIKey     string `envconfig:"TRANSLATE_API_KEY"`
+	TranslateAPIEmail   string `envconfig:"TRANSLATE_API_EMAIL"`
 
 	TrustedPubKeysHex []string `envconfig:"TRUSTED_PUBKEYS"`
 	trustedPubKeys    []nostr.PubKey
@@ -174,6 +177,8 @@ func main() {
 	sub.HandleFunc("/image/", renderImage)
 	sub.HandleFunc("/njump/proxy/", proxy)
 	sub.HandleFunc("/proxy/", proxy)
+	sub.HandleFunc("/njump/translate", translateProxy)
+	sub.HandleFunc("/translate", translateProxy)
 	sub.HandleFunc("/robots.txt", renderRobots)
 	sub.HandleFunc("/r/", renderRelayPage)
 	sub.HandleFunc("/random", redirectToRandom)

--- a/note.templ
+++ b/note.templ
@@ -17,7 +17,7 @@ type NotePageParams struct {
 	GroupLink        string
 }
 
-templ noteInnerBlock(params NotePageParams) {
+templ noteInnerBlock(params NotePageParams, showTranslate bool) {
 	if params.Event.subject != "" {
 		<h1 class="text-2xl" itemprop="headline">{ params.Event.subject }</h1>
 	} else {
@@ -38,10 +38,25 @@ templ noteInnerBlock(params NotePageParams) {
 	if params.Cover != "" {
 		<img src={ params.Cover } alt={ params.Alt } class="mt-1"/>
 	}
+	if showTranslate && translateConfigured() {
+		<div class="not-prose -mt-2 mb-3 text-right">
+			<button
+				type="button"
+				class="njump-translate-btn"
+				data-label-show="Translate"
+				data-label-hide="Show original"
+				data-label-loading="Translating…"
+				data-label-error="Translation failed"
+			>Translate</button>
+		</div>
+	}
 	<!-- main content -->
 	<div dir="auto" class="leading-6" itemprop="articleBody">
 		@templ.Raw(params.Content)
 	</div>
+	if showTranslate && translateConfigured() {
+		<script src={ "/njump/static/translate.js?t=" + compileTimeTs }></script>
+	}
 }
 
 templ noteTemplate(params NotePageParams, isEmbed bool) {
@@ -51,7 +66,7 @@ templ noteTemplate(params NotePageParams, isEmbed bool) {
 			params.Event,
 			params.NeventNaked,
 		) {
-			@noteInnerBlock(params)
+			@noteInnerBlock(params, false)
 		}
 	} else {
 		@eventPageTemplate(
@@ -62,7 +77,7 @@ templ noteTemplate(params NotePageParams, isEmbed bool) {
 			params.Details,
 			params.Event,
 		) {
-			@noteInnerBlock(params)
+			@noteInnerBlock(params, true)
 		}
 	}
 }

--- a/static/translate.js
+++ b/static/translate.js
@@ -1,0 +1,81 @@
+// Translate only the nostr post body (the [itemprop="articleBody"] element)
+// into the visitor's browser language.
+// The request is proxied through njump's own /njump/translate endpoint, which
+// forwards it to the configured translation backend (keeping any API key secret
+// and avoiding CORS). Self-contained: injects its own styles so no Tailwind
+// rebuild is needed.
+(function () {
+  var style = document.createElement('style')
+  style.textContent =
+    '.njump-translate-btn{background:none;border:none;padding:0;cursor:pointer;' +
+    'font:inherit;font-size:0.8rem;color:#a8a29e;text-decoration:underline;' +
+    'text-underline-offset:2px;}' +
+    '.njump-translate-btn:hover{color:#e32a6d;}' +
+    '.njump-translate-btn[disabled]{cursor:default;opacity:0.6;}' +
+    '.njump-translation{margin-top:0.75rem;border-left:3px solid #e32a6d;' +
+    'padding-left:0.75rem;white-space:pre-wrap;line-height:1.5rem;}'
+  document.head.appendChild(style)
+
+  function targetLang() {
+    var l = navigator.language || navigator.userLanguage || 'en'
+    return l.split('-')[0].toLowerCase()
+  }
+
+  function translate(text, target) {
+    return fetch('/njump/translate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ q: text, target: target }),
+    })
+      .then(function (r) {
+        if (!r.ok) throw new Error('HTTP ' + r.status)
+        return r.json()
+      })
+      .then(function (data) {
+        return (data && data.translatedText) || ''
+      })
+  }
+
+  document.addEventListener('click', function (ev) {
+    var btn = ev.target.closest && ev.target.closest('.njump-translate-btn')
+    if (!btn) return
+    ev.preventDefault()
+
+    var content = document.querySelector('[itemprop="articleBody"]')
+    if (!content) return
+
+    var existing = document.querySelector('.njump-translation')
+    if (existing) {
+      existing.remove()
+      btn.textContent = btn.getAttribute('data-label-show')
+      return
+    }
+
+    var text = (content.innerText || content.textContent || '').trim()
+    if (!text) return
+
+    btn.disabled = true
+    btn.textContent = btn.getAttribute('data-label-loading') || '…'
+
+    translate(text, targetLang())
+      .then(function (translated) {
+        var box = document.createElement('div')
+        box.className = 'njump-translation'
+        box.lang = targetLang()
+        box.setAttribute('dir', 'auto')
+        box.textContent = translated
+        content.insertAdjacentElement('afterend', box)
+        btn.textContent = btn.getAttribute('data-label-hide') || 'Show original'
+      })
+      .catch(function (err) {
+        console.error('njump translate:', err)
+        btn.textContent = btn.getAttribute('data-label-error') || 'Translation failed'
+        window.setTimeout(function () {
+          btn.textContent = btn.getAttribute('data-label-show')
+        }, 2500)
+      })
+      .finally(function () {
+        btn.disabled = false
+      })
+  })
+})()

--- a/translate.go
+++ b/translate.go
@@ -2,40 +2,40 @@ package main
 
 import (
 	"encoding/json"
-	"fmt"
 	"io"
 	"net/http"
-	"net/url"
 	"strings"
-	"time"
+	"sync"
+
+	"github.com/translated/lara-go/lara"
 )
 
-var translateHTTPClient = &http.Client{Timeout: 30 * time.Second}
+const translateMaxChars = 5000 // hard cap on a single request's text
 
-const (
-	translateMaxChars   = 5000 // hard cap on a single request's text
-	translateChunkChars = 480  // MyMemory rejects queries longer than 500 chars
+var (
+	laraOnce       sync.Once
+	laraTranslator *lara.Translator
 )
+
+// laraClient lazily builds the Lara translator from the configured credentials.
+func laraClient() *lara.Translator {
+	laraOnce.Do(func() {
+		creds := lara.NewCredentials(s.LaraAccessKeyID, s.LaraAccessKeySecret)
+		laraTranslator = lara.NewTranslator(creds, nil)
+	})
+	return laraTranslator
+}
 
 // translateConfigured reports whether a translation backend has been set up.
 // The translate button is only shown (and the endpoint only works) when it is.
 func translateConfigured() bool {
-	return s.TranslateAPIURL != ""
+	return s.LaraAccessKeyID != "" && s.LaraAccessKeySecret != ""
 }
 
-type myMemoryResponse struct {
-	ResponseData struct {
-		TranslatedText   string `json:"translatedText"`
-		DetectedLanguage string `json:"detectedLanguage"`
-	} `json:"responseData"`
-	ResponseStatus  json.Number `json:"responseStatus"`
-	ResponseDetails string      `json:"responseDetails"`
-}
-
-// translateProxy translates the post body through MyMemory. Going through the
-// server keeps any API key/email out of the client and avoids CORS, so the
-// browser only ever talks to njump's own origin. MyMemory caps a single query
-// at 500 chars, so longer text is split into chunks here.
+// translateProxy translates the post body through Lara. Going through the server
+// keeps the API credentials out of the client and avoids CORS, so the browser
+// only ever talks to njump's own origin. Lara auto-detects the source language
+// and handles long text, so the whole body is sent in a single request.
 func translateProxy(w http.ResponseWriter, r *http.Request) {
 	if !translateConfigured() {
 		http.Error(w, "translation not configured", http.StatusNotImplemented)
@@ -63,89 +63,23 @@ func translateProxy(w http.ResponseWriter, r *http.Request) {
 		req.Q = string(runes[:translateMaxChars])
 	}
 
-	var out strings.Builder
-	detected := ""
-	for _, chunk := range chunkText(req.Q, translateChunkChars) {
-		translated, dl, err := myMemoryTranslate(chunk, req.Target)
-		if err != nil {
-			log.Warn().Err(err).Msg("translation failed")
-			http.Error(w, "translation service unavailable", http.StatusBadGateway)
-			return
-		}
-		if detected == "" {
-			detected = dl
-		}
-		out.WriteString(translated)
+	// empty source => Lara auto-detects the language.
+	result, err := laraClient().Translate(req.Q, "", req.Target, lara.TranslateOptions{})
+	if err != nil {
+		log.Warn().Err(err).Msg("translation failed")
+		http.Error(w, "translation service unavailable", http.StatusBadGateway)
+		return
+	}
+
+	translated := ""
+	if result.Translation.String != nil {
+		translated = *result.Translation.String
 	}
 
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("Cache-Control", "max-age=86400")
 	json.NewEncoder(w).Encode(map[string]string{
-		"translatedText":   out.String(),
-		"detectedLanguage": detected,
+		"translatedText":   translated,
+		"detectedLanguage": result.SourceLanguage,
 	})
-}
-
-func myMemoryTranslate(text, target string) (translated, detected string, err error) {
-	q := url.Values{}
-	q.Set("q", text)
-	q.Set("langpair", "Autodetect|"+target)
-	if s.TranslateAPIKey != "" {
-		q.Set("key", s.TranslateAPIKey)
-	}
-	if s.TranslateAPIEmail != "" {
-		q.Set("de", s.TranslateAPIEmail)
-	}
-
-	endpoint := strings.TrimRight(s.TranslateAPIURL, "/") + "/get?" + q.Encode()
-	resp, err := translateHTTPClient.Get(endpoint)
-	if err != nil {
-		return "", "", err
-	}
-	defer resp.Body.Close()
-
-	var mm myMemoryResponse
-	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&mm); err != nil {
-		return "", "", err
-	}
-	if status := mm.ResponseStatus.String(); status != "" && status != "200" {
-		return "", "", fmt.Errorf("mymemory %s: %s", status, mm.ResponseDetails)
-	}
-	return mm.ResponseData.TranslatedText, mm.ResponseData.DetectedLanguage, nil
-}
-
-// chunkText splits text into pieces of at most maxRunes characters, preferring
-// to break on a newline or space so words stay intact. All characters
-// (including the separators) are preserved, so the chunks rejoin into the
-// original text.
-func chunkText(text string, maxRunes int) []string {
-	runes := []rune(text)
-	var chunks []string
-	for len(runes) > 0 {
-		if len(runes) <= maxRunes {
-			chunks = append(chunks, string(runes))
-			break
-		}
-		cut := 0
-		for i := maxRunes; i > maxRunes/2; i-- {
-			if runes[i] == '\n' {
-				cut = i + 1
-				break
-			}
-		}
-		if cut == 0 {
-			for i := maxRunes; i > maxRunes/2; i-- {
-				if runes[i] == ' ' {
-					cut = i + 1
-					break
-				}
-			}
-		}
-		if cut == 0 {
-			cut = maxRunes // no boundary found (e.g. CJK), hard cut
-		}
-		chunks = append(chunks, string(runes[:cut]))
-		runes = runes[cut:]
-	}
-	return chunks
 }

--- a/translate.go
+++ b/translate.go
@@ -1,0 +1,151 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+var translateHTTPClient = &http.Client{Timeout: 30 * time.Second}
+
+const (
+	translateMaxChars   = 5000 // hard cap on a single request's text
+	translateChunkChars = 480  // MyMemory rejects queries longer than 500 chars
+)
+
+// translateConfigured reports whether a translation backend has been set up.
+// The translate button is only shown (and the endpoint only works) when it is.
+func translateConfigured() bool {
+	return s.TranslateAPIURL != ""
+}
+
+type myMemoryResponse struct {
+	ResponseData struct {
+		TranslatedText   string `json:"translatedText"`
+		DetectedLanguage string `json:"detectedLanguage"`
+	} `json:"responseData"`
+	ResponseStatus  json.Number `json:"responseStatus"`
+	ResponseDetails string      `json:"responseDetails"`
+}
+
+// translateProxy translates the post body through MyMemory. Going through the
+// server keeps any API key/email out of the client and avoids CORS, so the
+// browser only ever talks to njump's own origin. MyMemory caps a single query
+// at 500 chars, so longer text is split into chunks here.
+func translateProxy(w http.ResponseWriter, r *http.Request) {
+	if !translateConfigured() {
+		http.Error(w, "translation not configured", http.StatusNotImplemented)
+		return
+	}
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req struct {
+		Q      string `json:"q"`
+		Target string `json:"target"`
+	}
+	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<16)).Decode(&req); err != nil {
+		http.Error(w, "bad request", http.StatusBadRequest)
+		return
+	}
+	req.Q = strings.TrimSpace(req.Q)
+	if req.Q == "" || req.Target == "" {
+		http.Error(w, "missing q or target", http.StatusBadRequest)
+		return
+	}
+	if runes := []rune(req.Q); len(runes) > translateMaxChars {
+		req.Q = string(runes[:translateMaxChars])
+	}
+
+	var out strings.Builder
+	detected := ""
+	for _, chunk := range chunkText(req.Q, translateChunkChars) {
+		translated, dl, err := myMemoryTranslate(chunk, req.Target)
+		if err != nil {
+			log.Warn().Err(err).Msg("translation failed")
+			http.Error(w, "translation service unavailable", http.StatusBadGateway)
+			return
+		}
+		if detected == "" {
+			detected = dl
+		}
+		out.WriteString(translated)
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Cache-Control", "max-age=86400")
+	json.NewEncoder(w).Encode(map[string]string{
+		"translatedText":   out.String(),
+		"detectedLanguage": detected,
+	})
+}
+
+func myMemoryTranslate(text, target string) (translated, detected string, err error) {
+	q := url.Values{}
+	q.Set("q", text)
+	q.Set("langpair", "Autodetect|"+target)
+	if s.TranslateAPIKey != "" {
+		q.Set("key", s.TranslateAPIKey)
+	}
+	if s.TranslateAPIEmail != "" {
+		q.Set("de", s.TranslateAPIEmail)
+	}
+
+	endpoint := strings.TrimRight(s.TranslateAPIURL, "/") + "/get?" + q.Encode()
+	resp, err := translateHTTPClient.Get(endpoint)
+	if err != nil {
+		return "", "", err
+	}
+	defer resp.Body.Close()
+
+	var mm myMemoryResponse
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&mm); err != nil {
+		return "", "", err
+	}
+	if status := mm.ResponseStatus.String(); status != "" && status != "200" {
+		return "", "", fmt.Errorf("mymemory %s: %s", status, mm.ResponseDetails)
+	}
+	return mm.ResponseData.TranslatedText, mm.ResponseData.DetectedLanguage, nil
+}
+
+// chunkText splits text into pieces of at most maxRunes characters, preferring
+// to break on a newline or space so words stay intact. All characters
+// (including the separators) are preserved, so the chunks rejoin into the
+// original text.
+func chunkText(text string, maxRunes int) []string {
+	runes := []rune(text)
+	var chunks []string
+	for len(runes) > 0 {
+		if len(runes) <= maxRunes {
+			chunks = append(chunks, string(runes))
+			break
+		}
+		cut := 0
+		for i := maxRunes; i > maxRunes/2; i-- {
+			if runes[i] == '\n' {
+				cut = i + 1
+				break
+			}
+		}
+		if cut == 0 {
+			for i := maxRunes; i > maxRunes/2; i-- {
+				if runes[i] == ' ' {
+					cut = i + 1
+					break
+				}
+			}
+		}
+		if cut == 0 {
+			cut = maxRunes // no boundary found (e.g. CJK), hard cut
+		}
+		chunks = append(chunks, string(runes[:cut]))
+		runes = runes[cut:]
+	}
+	return chunks
+}


### PR DESCRIPTION
Adds a small "Translate" button on note pages that translates only the post body (the [itemprop="articleBody"] element) into the visitor's browser language. The button only shows on full note pages (not in embeds) and toggles between the translation and the original; the original content is left untouched and the translated text is shown in a separate block right below it.

Translation goes through njump's own `/njump/translate` endpoint, which proxies to [Lara](https://laratranslate.com/) using the official Go SDK (`github.com/translated/lara-go`). Proxying server-side keeps the API credentials out of the client and avoids CORS, so the browser only ever talks to njump's own origin. Lara auto-detects the source language and handles long text in a single request.

Configure with the `LARA_ACCESS_KEY_ID` and `LARA_ACCESS_KEY_SECRET` environment variables. The button (and the endpoint) are only enabled when both are set.

<img width="373" height="185" alt="image" src="https://github.com/user-attachments/assets/bdfbe363-161a-4e63-b8c2-af437d0d9e2e" />